### PR TITLE
Add Forge OIDC application

### DIFF
--- a/terraform/authentik/applications.tf
+++ b/terraform/authentik/applications.tf
@@ -5,6 +5,7 @@ locals {
     "reactive-resume",
     "paperless",
     "trek",
+    "forge",
   ]
 }
 
@@ -58,6 +59,14 @@ locals {
       icon_url      = "https://cdn.jsdelivr.net/gh/selfhst/icons/png/trek.png"
       redirect_uris = ["https://trek.${var.cluster_domain}/api/auth/oidc/callback"]
       launch_url    = "https://trek.${var.cluster_domain}"
+    },
+    forge = {
+      client_id     = "forge"
+      client_secret = module.onepassword_application["forge"].fields["FORGE_OIDC_CLIENT_SECRET"]
+      group         = authentik_group.admins.id
+      icon_url      = "https://cdn.jsdelivr.net/gh/selfhst/icons/png/forge.png"
+      redirect_uris = ["https://forge.${var.cluster_domain}/auth/callback"]
+      launch_url    = "https://forge.${var.cluster_domain}"
     },
   }
 }


### PR DESCRIPTION
## Summary
- register Forge as an Authentik OAuth application
- use the existing forge 1Password OIDC client secret
- configure the Forge callback and launch URLs

## Verification
- `tofu fmt -check -diff terraform/authentik/applications.tf`
- `tofu -chdir=terraform/authentik init -backend=false -input=false`
- `tofu -chdir=terraform/authentik validate`
- repository pre-commit hooks pass; terraform-docs hook was skipped because terraform-docs is not installed locally